### PR TITLE
Use the real path of Titanfall-2-Icepick.exe when loading mods instead of the working directory

### DIFF
--- a/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
+++ b/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
@@ -59,7 +59,7 @@ namespace Icepick.Controls
 			ModDescription = mod.Definition?.Description;
 			if ( !string.IsNullOrEmpty( mod.ImagePath ) )
 			{
-				ModImage = System.IO.Path.Combine( Environment.CurrentDirectory, mod.ImagePath );
+				ModImage = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, mod.ImagePath );
 			}
 
 			Mod_OnStatusUpdated();
@@ -121,7 +121,7 @@ namespace Icepick.Controls
 
 		private void ShowInExplorer_Click( object sender, RoutedEventArgs e )
 		{
-			string path = System.IO.Path.Combine( Environment.CurrentDirectory, Mod.Directory );
+			string path = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, Mod.Directory );
 			System.Diagnostics.Process.Start( path );
 		}
 

--- a/Titanfall-2-Icepick/CrashReporting/CrashReporter.cs
+++ b/Titanfall-2-Icepick/CrashReporting/CrashReporter.cs
@@ -22,7 +22,7 @@ namespace Icepick.CrashReporting
 
 		public static void StartWatching()
 		{
-			string crashDumpsPath = Path.Combine( Environment.CurrentDirectory, "data", "crash_dumps" );
+			string crashDumpsPath = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, "data", "crash_dumps" );
 			if( !Directory.Exists( crashDumpsPath ) )
 			{
 				Directory.CreateDirectory( crashDumpsPath );
@@ -97,7 +97,7 @@ namespace Icepick.CrashReporting
 			}
 
 			// Get disk space information
-			string rootPath = Path.GetPathRoot(Environment.CurrentDirectory);
+			string rootPath = Path.GetPathRoot(AppDomain.CurrentDomain.BaseDirectory);
 			ulong freeStorage = 0;
 			ulong storageSize = 0;
 			ulong dummy;

--- a/Titanfall-2-Icepick/Mods/ModDatabase.cs
+++ b/Titanfall-2-Icepick/Mods/ModDatabase.cs
@@ -35,13 +35,13 @@ namespace Icepick.Mods
 
 		public static void ShowModsFolder()
 		{
-			string path = System.IO.Path.Combine( Environment.CurrentDirectory, ModDatabase.ModsDirectory );
+			string path = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModDatabase.ModsDirectory );
 			System.Diagnostics.Process.Start( path );
 		}
 
 		public static void ShowSavesFolder()
 		{
-			string path = System.IO.Path.Combine( Environment.CurrentDirectory, ModDatabase.SavesDirectory );
+			string path = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModDatabase.SavesDirectory );
 			System.Diagnostics.Process.Start( path );
 		}
 
@@ -84,7 +84,7 @@ namespace Icepick.Mods
 		{
 			if ( Path.GetExtension( path ) == ArchiveExtension )
 			{
-				string modsFullDirectory = Path.Combine( Environment.CurrentDirectory, ModsDirectory );
+				string modsFullDirectory = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModsDirectory );
 				Console.WriteLine( modsFullDirectory );
 
 				// Check if a mod already exists
@@ -142,7 +142,7 @@ namespace Icepick.Mods
 					else if( foundSaveFile )
 					{
 						// Extract saves to the saves folder
-						destinationFolder = Path.Combine( Environment.CurrentDirectory, SavesDirectory );
+						destinationFolder = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, SavesDirectory );
 						ZipFile.ExtractToDirectory( path, destinationFolder );
 
 						if ( OnFinishedImportingMod != null )
@@ -168,8 +168,8 @@ namespace Icepick.Mods
 
 		public static string PackageMod( string path )
 		{
-			string exportPath = Path.Combine( Environment.CurrentDirectory, ModsDirectory, Path.GetFileName( path ) ) + ArchiveExtension;
-			string modDirectory = Path.Combine( Environment.CurrentDirectory, path );
+			string exportPath = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModsDirectory, Path.GetFileName( path ) ) + ArchiveExtension;
+			string modDirectory = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, path );
 			string errorMessage = null;
 
 			try

--- a/Titanfall-2-Icepick/Mods/SDKInjector.cs
+++ b/Titanfall-2-Icepick/Mods/SDKInjector.cs
@@ -121,7 +121,7 @@ namespace Icepick.Mods
 			}
 
 			Injector syringe = new Injector( targetProcess );
-			syringe.SetDLLSearchPath( System.IO.Directory.GetCurrentDirectory() );
+			syringe.SetDLLSearchPath( AppDomain.CurrentDomain.BaseDirectory );
 			syringe.InjectLibrary( SDKDllName );
 
 			SDKSettings settings = new SDKSettings();


### PR DESCRIPTION
This fixes the issue where running the exe from the command line would try to load data from the path where the exe was launched from, which isn't necessarily where it's actually installed.