### PR TITLE
Fix crash when opening a folder when it doesn't exist

### DIFF
--- a/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
+++ b/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
@@ -146,7 +146,7 @@ namespace Icepick.Controls
 			string errorMessage = Mods.ModDatabase.PackageMod( Mod.Directory );
 			if ( errorMessage == null )
 			{
-				Mods.ModDatabase.ShowModsFolder();
+				Mods.ModDatabase.ShowFolder(Mods.ModDatabase.ModsDirectory);
 			}
 			else
 			{

--- a/Titanfall-2-Icepick/MainWindow.xaml
+++ b/Titanfall-2-Icepick/MainWindow.xaml
@@ -24,7 +24,7 @@
                     <Separator/>
                     <MenuItem Header="Select _Game Location" Click="SelectGameLocation_Click" />
                     <Separator/>
-                    <MenuItem Header="_Quit" />
+                    <MenuItem Header="_Quit" Click="Quit_Click" />
                 </MenuItem>
                 <MenuItem Header="_Settings">
                     <MenuItem x:Name="btnDisableCrashReports" Header="Disable _Crash Reports" IsCheckable="True" IsChecked="{Binding CrashReportingDisabled}"/>

--- a/Titanfall-2-Icepick/MainWindow.xaml.cs
+++ b/Titanfall-2-Icepick/MainWindow.xaml.cs
@@ -221,7 +221,7 @@ namespace Icepick
 		}
 
 		private void Quit_Click(object sender, RoutedEventArgs e)
-        {
+		{
 			Application.Current.Shutdown();
 		}
 

--- a/Titanfall-2-Icepick/MainWindow.xaml.cs
+++ b/Titanfall-2-Icepick/MainWindow.xaml.cs
@@ -191,12 +191,12 @@ namespace Icepick
 
 		private void OpenModsFolder_Click( object sender, RoutedEventArgs e )
 		{
-			ModDatabase.ShowModsFolder();
+			ModDatabase.ShowFolder(ModDatabase.ModsDirectory);
 		}
 
 		private void OpenSavesFolder_Click( object sender, RoutedEventArgs e )
 		{
-			ModDatabase.ShowSavesFolder();
+			ModDatabase.ShowFolder(ModDatabase.SavesDirectory);
 		}
 
 		private void ReloadMods_Click( object sender, RoutedEventArgs e )

--- a/Titanfall-2-Icepick/MainWindow.xaml.cs
+++ b/Titanfall-2-Icepick/MainWindow.xaml.cs
@@ -220,6 +220,11 @@ namespace Icepick
 			Api.IcepickRegistry.ClearRegistry();
 		}
 
+		private void Quit_Click(object sender, RoutedEventArgs e)
+        {
+			Application.Current.Shutdown();
+		}
+
 		private void LaunchGame_Click( object sender, RoutedEventArgs e )
 		{
 			string gamePath = Api.IcepickRegistry.AttemptReadRespawnRegistryPath() ?? Api.IcepickRegistry.ReadGameInstallPath();

--- a/Titanfall-2-Icepick/Mods/ModDatabase.cs
+++ b/Titanfall-2-Icepick/Mods/ModDatabase.cs
@@ -34,10 +34,10 @@ namespace Icepick.Mods
 		public static List<TitanfallMod> LoadedMods = new List<TitanfallMod>();
 
 		public static void ShowFolder(string directory)
-        {
+		{
 			string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directory);
 			if (!Directory.Exists(path))
-            {
+			{
 				MessageBox.Show($"The directory '{path}' is missing!", "Missing Directory", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 				return;
 			}

--- a/Titanfall-2-Icepick/Mods/ModDatabase.cs
+++ b/Titanfall-2-Icepick/Mods/ModDatabase.cs
@@ -33,16 +33,15 @@ namespace Icepick.Mods
 
 		public static List<TitanfallMod> LoadedMods = new List<TitanfallMod>();
 
-		public static void ShowModsFolder()
-		{
-			string path = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModDatabase.ModsDirectory );
-			System.Diagnostics.Process.Start( path );
-		}
-
-		public static void ShowSavesFolder()
-		{
-			string path = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModDatabase.SavesDirectory );
-			System.Diagnostics.Process.Start( path );
+		public static void ShowFolder(string directory)
+        {
+			string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directory);
+			if (!Directory.Exists(path))
+            {
+				MessageBox.Show($"The directory '{path}' is missing!", "Missing Directory", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+				return;
+			}
+			System.Diagnostics.Process.Start(path);
 		}
 
 		public static void ClearDatabase()


### PR DESCRIPTION
Previously, when clicking "Show mods/saves folder" in the menu, IcePick would silently crash. The first commit fixes this and displays an error message instead, which contains the full path of whatever was attempted to open. Should make it easier to debug broken installs.

The second commit introduces functionality to the Quit button in the menu. Previously, it was bound to nothing and did nothing.