### PR TITLE
Allow mods to be toggled

### DIFF
--- a/Titanfall-2-Icepick/Controls/ModItem.xaml
+++ b/Titanfall-2-Icepick/Controls/ModItem.xaml
@@ -4,7 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Icepick.Controls"
-             mc:Ignorable="d" d:DesignWidth="300" Height="50">
+             mc:Ignorable="d" d:DesignWidth="300" Height="50"
+             MouseDoubleClick="ToggleMod_Click">
     <Grid>
         <Label x:Name="ModNameLabel" Content="Unnamed Mod" VerticalAlignment="Top" FontWeight="Bold" Margin="55,0,0,0" FontSize="14"/>
         <Label x:Name="ModDescriptionLabel" Content="Mod Description." VerticalAlignment="Top" Margin="55,20,0,0" FontStyle="Italic"/>
@@ -21,6 +22,8 @@
         </Grid.ToolTip>
         <Grid.ContextMenu>
             <ContextMenu>
+                <MenuItem x:Name="EnabledMenuItem" Header="Enabled" IsChecked="True" Click="ToggleMod_Click"/>
+                <Separator/>
                 <MenuItem x:Name="ViewDetailsMenuItem" Header="View Details" Click="ViewDetails_Click" />
                 <MenuItem Header="Show in Explorer" Click="ShowInExplorer_Click" />
                 <Separator/>

--- a/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
+++ b/Titanfall-2-Icepick/Controls/ModItem.xaml.cs
@@ -56,6 +56,7 @@ namespace Icepick.Controls
 
 			ModName = mod.Definition?.Name;
 			ModDescription = mod.Definition?.Description;
+			ModEnabled = mod.Enabled;
 			if ( !string.IsNullOrEmpty( mod.ImagePath ) )
 			{
 				ModImage = System.IO.Path.Combine( AppDomain.CurrentDomain.BaseDirectory, mod.ImagePath );
@@ -87,6 +88,25 @@ namespace Icepick.Controls
 			get
 			{
 				return (string) ModDescriptionLabel.Content;
+			}
+		}
+
+		public bool ModEnabled
+		{
+			set
+			{
+				if (value)
+				{
+					Opacity = 1.0;
+					ModStatusImage.Visibility = Visibility.Visible;
+				}
+				else
+				{
+					Opacity = 0.5;
+					ModStatusImage.Visibility = Visibility.Hidden;
+				}
+				EnabledMenuItem.IsChecked = value;
+				Mod.Enabled = value;
 			}
 		}
 
@@ -140,6 +160,18 @@ namespace Icepick.Controls
 			else
 			{
 				MessageBox.Show( $"Could not package mod.\n{errorMessage}", "Package Error", MessageBoxButton.OK, MessageBoxImage.Exclamation );
+			}
+		}
+
+		private void ToggleMod_Click(object sender, RoutedEventArgs e)
+		{
+			try
+			{
+				ModEnabled = Mods.ModDatabase.ToggleMod(Mod.Directory);
+			}
+			catch (Exception err)
+			{
+				MessageBox.Show($"Could not {(Mod.Enabled ? "disable" : "enable")} mod.\n{err.Message}", "Toggle Mod Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 			}
 		}
 

--- a/Titanfall-2-Icepick/Mods/ModDatabase.cs
+++ b/Titanfall-2-Icepick/Mods/ModDatabase.cs
@@ -132,6 +132,11 @@ namespace Icepick.Mods
 						// Extract mod to the mods folder
 						ZipFile.ExtractToDirectory( path, destinationFolder );
 
+						if (File.Exists(Path.Combine(destinationFolder, DisabledFileName)))
+						{
+							File.Delete(Path.Combine(destinationFolder, DisabledFileName));
+						}
+
 						if ( OnFinishedImportingMod != null )
 						{
 							OnFinishedImportingMod( true, ModImportType.Mod, $"{modFolderName} imported successfully!" );
@@ -168,11 +173,25 @@ namespace Icepick.Mods
 		{
 			string exportPath = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, ModsDirectory, Path.GetFileName( path ) ) + ArchiveExtension;
 			string modDirectory = Path.Combine( AppDomain.CurrentDomain.BaseDirectory, path );
+			string disabledFilePath = Path.Combine(modDirectory, DisabledFileName);
 			string errorMessage = null;
 
 			try
 			{
+				bool isDisabled = File.Exists(disabledFilePath);
+				if (isDisabled)
+				{
+					// prevent packaging the disabled status file
+					File.Delete(disabledFilePath);
+				}
+
 				ZipFile.CreateFromDirectory( modDirectory, exportPath );
+
+				if (isDisabled)
+				{
+					// recreate the disabled status file if applicable
+					File.Create(disabledFilePath).Close();
+				}
 			}
 			catch( Exception e )
 			{

--- a/Titanfall-2-Icepick/Mods/ModDatabase.cs
+++ b/Titanfall-2-Icepick/Mods/ModDatabase.cs
@@ -17,6 +17,7 @@ namespace Icepick.Mods
 
 		public const string ModsDirectory = @"data\mods";
 		public const string SavesDirectory = @"data\saves";
+		public const string DisabledFileName = "disabled";
 		private const string ArchiveExtension = ".zip";
 
 		public delegate void ModDatabaseDelegate();
@@ -179,6 +180,20 @@ namespace Icepick.Mods
 			}
 
 			return errorMessage;
+		}
+
+		public static bool ToggleMod(string path)
+		{
+			string disabledFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ModsDirectory, Path.GetFileName(path), DisabledFileName);
+
+			if (File.Exists(disabledFilePath))
+			{
+				File.Delete(disabledFilePath);
+				return true;
+			}
+
+			File.Create(disabledFilePath).Close();
+			return false;
 		}
 
 	}

--- a/Titanfall-2-Icepick/Mods/TitanfallMod.cs
+++ b/Titanfall-2-Icepick/Mods/TitanfallMod.cs
@@ -8,11 +8,13 @@ namespace Icepick.Mods
 	{
 		public const string ModDocumentFile = "mod.json";
 		const string ModImage = "mod.png";
+		const string DisabledFile = "disabled";
 		const string IcepickModName = "Icepick Framework";
 
 		public TitanfallModDefinition Definition;
 		public string ImagePath;
 		public string Directory;
+		public bool Enabled;
 
 		public TitanfallMod( string Directory )
 		{
@@ -34,6 +36,9 @@ namespace Icepick.Mods
 			{
 				ImagePath = modImagePath;
 			}
+
+			string disabledFilePath = Path.Combine(Directory, DisabledFile);
+			Enabled = !File.Exists(disabledFilePath);
 		}
 
 		public bool IsIcepickFramework


### PR DESCRIPTION
This PR introduces functionality to enable or disable mods in Icepick. This can be achieved by either double clicking the mod in question, or toggling the `Enabled` option in its context menu:

![2PdPrYpJ](https://user-images.githubusercontent.com/36747857/125942438-da109e4e-ab63-4eff-b7a9-fc575b663356.gif)

Behind the scenes, this works by simply creating or deleting a file named `disabled` in the corresponding mod's directory. It requires https://github.com/Titanfall-Mods/TTF2SDK/commit/50c747a3f8f2d895ea6e1250b7bfb983197a1abf to have any effect in-game.

The mod packaging was also modified to disregard the `disabled` file when creating or importing a mod package.